### PR TITLE
fixed サイト基本設定でCkEditor以外のエディターを設定している場合、ブログ記事概要欄の画像選択ボタンでアップローダが利用できな…

### DIFF
--- a/Event/UploaderControllerEventListener.php
+++ b/Event/UploaderControllerEventListener.php
@@ -1,0 +1,24 @@
+<?php
+class UploaderControllerEventListener extends BcControllerEventListener {
+/**
+ * 登録イベント
+ *
+ * @var array
+ */
+	public $events = array(
+		'startup'
+	);
+	
+/**
+ * startup
+ * 
+ * @param CakeEvent $event
+ */
+	public function startup(CakeEvent $event) {
+		$Controller = $event->subject();
+		if (!in_array('BcCkeditor', $Controller->helpers)) {
+			$Controller->helpers[] = 'BcCkeditor';
+		}
+	}
+	
+}


### PR DESCRIPTION
…い点を改修

- プラグインを有効化しても、CkEditor利用箇所では全て画像アップロード呼出ができなくなっている点の改修（ブログコンテンツ概要欄、フォーム概要欄、エディタテンプレ編集等）
- コアの方では、サイト基本設定の指定エディタの設定値と呼び出すHelperが連動しており、CkEditor以外の設定値の場合、BcCkEditorHelperがコントローラ側で読み込まれない仕様となっているため